### PR TITLE
update depricated api's

### DIFF
--- a/src/collision_map_creator.cc
+++ b/src/collision_map_creator.cc
@@ -32,7 +32,7 @@ class CollisionMapCreator : public WorldPlugin
     node = transport::NodePtr(new transport::Node());
     world = _parent;
     // Initialize the node with the world name
-    node->Init(world->GetName());
+    node->Init(world->Name());
     std::cout << "Subscribing to: " << "~/collision_map/command" << std::endl;
     commandSubscriber = node->Subscribe("~/collision_map/command",
       &CollisionMapCreator::create, this);
@@ -88,7 +88,7 @@ class CollisionMapCreator : public WorldPlugin
     start.Z(msg->height());
     end.Z(0.001);
 
-    gazebo::physics::PhysicsEnginePtr engine = world->GetPhysicsEngine();
+    gazebo::physics::PhysicsEnginePtr engine = world->Physics();
     engine->InitForThread();
     gazebo::physics::RayShapePtr ray =
       boost::dynamic_pointer_cast<gazebo::physics::RayShape>(


### PR DESCRIPTION
**catkin_make** fails with following error msg:
```
/notebooks/catkin_ws_kinetic/src/pgm_map_creator/src/collision_map_creator.cc: In m
ember function ‘virtual void gazebo::CollisionMapCreator::Load(gazebo::physics::Wor
ldPtr, sdf::ElementPtr)’:
/notebooks/catkin_ws_kinetic/src/pgm_map_creator/src/collision_map_creator.cc:35:23
: error: ‘class gazebo::physics::World’ has no member named ‘GetName’
     node->Init(world->GetName());
                       ^
/notebooks/catkin_ws_kinetic/src/pgm_map_creator/src/collision_map_creator.cc: In m
ember function ‘void gazebo::CollisionMapCreator::create(gazebo::CollisionMapReques
tPtr&)’:
/notebooks/catkin_ws_kinetic/src/pgm_map_creator/src/collision_map_creator.cc:91:55
: error: ‘class gazebo::physics::World’ has no member named ‘GetPhysicsEngine’
     gazebo::physics::PhysicsEnginePtr engine = world->GetPhysicsEngine();
```
Two Changes:
- Instead of  `physics::PhysicsEnginePtr engine = world->GetPhysicsEngine();`
  use `physics::PhysicsEnginePtr engine = world->Physics();`
[ref forum](http://answers.gazebosim.org/question/20861/when-trying-to-set_velocity_plugin-i-get-make-error-class-gazebophysicsworld-has-no-member-named-getphysicsengine/)

- Instead of `node->Init(_parent->GetName());`
  use `node->Init(_parent->Name());`
[ref forum](http://answers.gazebosim.org/question/16388/getname-has-not-been-declared-gazebo-9/)