### PR TITLE
Log out status "Waiting for connection ..."

### DIFF
--- a/src/request_publisher.cc
+++ b/src/request_publisher.cc
@@ -90,7 +90,9 @@ int main(int argc, char * argv[])
         gazebo::transport::PublisherPtr imagePub =
                 node->Advertise<collision_map_creator_msgs::msgs::CollisionMapRequest>(
                                                             "~/collision_map/command");
+        std::cout << "Waiting for connection ... " << std::endl;
         imagePub->WaitForConnection();
+        std::cout << "Connected." << std::endl;
         imagePub->Publish(request);
 
         gazebo::transport::fini();


### PR DESCRIPTION
Reason: when this script is waiting for a connection to the plugin, it does not output to the terminal that it is waiting. We might think that it is working on generating the map file but indeed it is still waiting forever. Logging out the waiting status to the terminal will be helpful.

I made a mistake before that my world file did not have "collision_map_creator" plugin yet. As a result, the script couldn't connect to the plugin and was just waiting. I thought it was generating the image and I was just waiting. To save time for someone in the future, I would like to add these log messages.